### PR TITLE
Fix version conflicts caused by PR#228

### DIFF
--- a/eFormCore/Microting.eForm.csproj
+++ b/eFormCore/Microting.eForm.csproj
@@ -253,8 +253,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.7.0.40" />
-    <PackageReference Include="AWSSDK.S3" Version="3.7.1.10" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.0.43" />
+    <PackageReference Include="AWSSDK.S3" Version="3.7.1.13" />
     <PackageReference Include="AWSSDK.SQS" Version="3.7.0.39" />
     <PackageReference Include="Castle.Core" Version="4.4.1" />
     <PackageReference Include="Castle.Windsor" Version="5.1.1" />


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump AWSSDK.S3 from 3.7.1.10 to 3.7.1.13. [(PR#228)](https://github.com/microting/eform-sdk-dotnet/pull/228).
Hope this fix can help you.

Best regards,
sucrose