### PR TITLE
feat(case-create): Settings.skipCloudDeploy + synthetic MicrotingUid range

### DIFF
--- a/eFormCore/Core.cs
+++ b/eFormCore/Core.cs
@@ -1447,11 +1447,16 @@ public class Core : CoreBase
             if (caseUId != "" && mainElement.Repeated != 1)
                 throw new ArgumentException("if caseUId can only be used for mainElement.Repeated == 1");
 
+            // Without a non-null MicrotingUid, CaseCreate's dedup probe would match every
+            // prior local-only row and collapse them onto a single shared null/null row.
+            int syntheticUid = await _sqlController.NextSyntheticMicrotingUidAsync();
+
             int caseId = await _sqlController.CaseCreate(
-                mainElement.Id, siteUid, null, null, caseUId, "", DateTime.UtcNow, folderId)
+                mainElement.Id, siteUid, syntheticUid, null, caseUId, "", DateTime.UtcNow, folderId)
                 .ConfigureAwait(false);
 
-            Log.LogInfo(methodName, $"local case row created with Id {caseId}");
+            Log.LogInfo(methodName,
+                $"local case row created with Id {caseId}, synthetic MicrotingUid {syntheticUid}");
             return caseId;
         }
         catch (Exception ex)
@@ -5448,6 +5453,14 @@ public class Core : CoreBase
         string methodName = "Core.SendXml";
         Log.LogDebug(methodName, "siteId:" + siteId + ", requested sent eForm");
 
+        if (await SkipCloudDeployAsync())
+        {
+            int syntheticUid = await _sqlController.NextSyntheticMicrotingUidAsync();
+            Log.LogDebug(methodName,
+                $"siteId:{siteId}, skipCloudDeploy=true; synthetic MicrotingUid={syntheticUid}");
+            return new Response(Response.ResponseTypes.Success, syntheticUid.ToString());
+        }
+
         string xmlStrRequest = mainElement.ClassToXml();
 
         Log.LogDebug(methodName, "siteId:" + siteId + ", ClassToXml done");
@@ -5459,6 +5472,13 @@ public class Core : CoreBase
         Log.LogDebug(methodName, "siteId:" + siteId + ", XmlToClass done");
 
         return response;
+    }
+
+    private async Task<bool> SkipCloudDeployAsync()
+    {
+        // Pre-existing installations may not have seeded the row after upgrade —
+        // FirstOrDefault so a missing row reads as "cloud deploy" rather than throwing.
+        return await _sqlController.SettingReadOrDefaultAsync(Settings.skipCloudDeploy) == "true";
     }
 
     /// <summary>

--- a/eFormCore/Dto/Settings.cs
+++ b/eFormCore/Dto/Settings.cs
@@ -63,5 +63,7 @@ public enum Settings
     translationsMigrated,
     pluginsEnabled,
     servicesEnabled,
-    comAddressNewApi
+    comAddressNewApi,
+    skipCloudDeploy,
+    syntheticMicrotingUidCounter
 }

--- a/eFormCore/Infrastructure/SqlController.cs
+++ b/eFormCore/Infrastructure/SqlController.cs
@@ -909,12 +909,15 @@ public class SqlController : LogWriter
             _log.LogInfo(methodName, $"siteId is {siteId}");
 
             Case aCase = null;
-            // Lets see if we have an existing case with the same parameters in the db first.
-            // This is to handle none gracefull shutdowns.
-            aCase = await db.Cases.FirstOrDefaultAsync(x =>
-                x.MicrotingUid == microtingUId && x.MicrotingCheckUid == microtingCheckId);
-            _log.LogInfo(methodName,
-                $"aCase found based on MicrotingUid == {microtingUId} and MicrotingCheckUid == {microtingCheckId}");
+            // Dedup recovers from ungraceful shutdowns of the cloud-deploy path; skipping
+            // when microtingUId is null avoids collapsing every (null, null) local-only row.
+            if (microtingUId != null)
+            {
+                aCase = await db.Cases.FirstOrDefaultAsync(x =>
+                    x.MicrotingUid == microtingUId && x.MicrotingCheckUid == microtingCheckId);
+                _log.LogInfo(methodName,
+                    $"aCase found based on MicrotingUid == {microtingUId} and MicrotingCheckUid == {microtingCheckId}");
+            }
 
             if (aCase == null)
             {
@@ -5310,6 +5313,8 @@ public class SqlController : LogWriter
         await SettingCreate(Settings.pluginsEnabled);
         await SettingCreate(Settings.servicesEnabled);
         await SettingCreate(Settings.comAddressNewApi);
+        await SettingCreate(Settings.skipCloudDeploy);
+        await SettingCreate(Settings.syntheticMicrotingUidCounter);
 
         return true;
     }
@@ -5511,6 +5516,14 @@ public class SqlController : LogWriter
                 id = 38;
                 defaultValue = "none";
                 break;
+            case Settings.skipCloudDeploy:
+                id = 39;
+                defaultValue = "false";
+                break;
+            case Settings.syntheticMicrotingUidCounter:
+                id = 40;
+                defaultValue = "2000000000";
+                break;
 
             default:
                 throw new IndexOutOfRangeException(name + " is not a known/mapped Settings type");
@@ -5558,6 +5571,69 @@ public class SqlController : LogWriter
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Returns the next MicrotingUid in the reserved local range
+    /// (>= 2_000_000_000) so generated ids never collide with cloud-assigned ids.
+    /// Used by the local-only Case creation paths (CaseCreateLocalOnly, and
+    /// SendXml when Settings.skipCloudDeploy is enabled).
+    /// </summary>
+    /// <remarks>
+    /// Concurrency: the UPDATE is row-locked by InnoDB, so concurrent callers —
+    /// across threads in one process AND across separate host processes hitting
+    /// the same DB — serialise on the Settings row. Each caller's connection
+    /// holds its own session-scoped LAST_INSERT_ID, so the follow-up SELECT
+    /// returns the value THIS caller just wrote. Both statements run on the
+    /// same connection captured from the DbContext.
+    /// </remarks>
+    public async Task<int> NextSyntheticMicrotingUidAsync()
+    {
+        const int localUidOffset = 2_000_000_000;
+        const int rangeExhaustionGuard = 2_100_000_000;
+        await using var db = GetContext();
+        var conn = db.Database.GetDbConnection();
+        if (conn.State != System.Data.ConnectionState.Open)
+            await conn.OpenAsync().ConfigureAwait(false);
+
+        await using var update = conn.CreateCommand();
+        update.CommandText =
+            $"UPDATE Settings " +
+            $"   SET Value = CAST(LAST_INSERT_ID(CAST(Value AS UNSIGNED) + 1) AS CHAR) " +
+            $" WHERE Name = '{nameof(Settings.syntheticMicrotingUidCounter)}'";
+        var affected = await update.ExecuteNonQueryAsync().ConfigureAwait(false);
+        if (affected == 0)
+        {
+            // Pre-existing installation whose SettingCreateDefaults predates this
+            // setting — seed it and retry once.
+            await SettingCreate(Settings.syntheticMicrotingUidCounter).ConfigureAwait(false);
+            affected = await update.ExecuteNonQueryAsync().ConfigureAwait(false);
+            if (affected == 0)
+                throw new Exception(
+                    "Failed to allocate synthetic MicrotingUid: counter row missing after seeding");
+        }
+
+        await using var select = conn.CreateCommand();
+        select.CommandText = "SELECT LAST_INSERT_ID()";
+        var raw = await select.ExecuteScalarAsync().ConfigureAwait(false);
+        long next = Convert.ToInt64(raw);
+        if (next < localUidOffset || next > rangeExhaustionGuard)
+            throw new Exception(
+                $"Synthetic MicrotingUid {next} outside the reserved local range " +
+                $"[{localUidOffset}, {rangeExhaustionGuard}]");
+        return (int)next;
+    }
+
+    /// <summary>
+    /// Like <see cref="SettingRead"/> but returns null when the row is missing
+    /// instead of throwing — for callers that legitimately treat "missing row"
+    /// as "default behavior" (e.g. callers that pre-date a new setting).
+    /// </summary>
+    public async Task<string> SettingReadOrDefaultAsync(Settings name)
+    {
+        await using var db = GetContext();
+        Setting match = await db.Settings.FirstOrDefaultAsync(x => x.Name == name.ToString());
+        return match?.Value;
     }
 
     /// <summary>

--- a/eFormSDK.Integration.Case.CoreTests/CoreTestCaseCreate.cs
+++ b/eFormSDK.Integration.Case.CoreTests/CoreTestCaseCreate.cs
@@ -172,7 +172,7 @@ public class CoreTestCaseCreate : DbTestFixture
     }
 
     [Test]
-    public async Task Core_Case_CaseCreateLocalOnly_InsertsRowWithNullMicrotingUid()
+    public async Task Core_Case_CaseCreateLocalOnly_InsertsRowWithSyntheticMicrotingUid()
     {
         CheckList cl1 = await testHelpers.CreateTemplate(
             DateTime.Now, DateTime.Now, "A", "D", "CheckList", "Folder", 1, 1);
@@ -189,7 +189,9 @@ public class CoreTestCaseCreate : DbTestFixture
         Assert.That(caseId, Is.Not.Null);
         var row = await DbContext.Cases.FirstOrDefaultAsync(x => x.Id == caseId.Value);
         Assert.That(row, Is.Not.Null, "the Cases row should exist");
-        Assert.That(row!.MicrotingUid, Is.Null, "MicrotingUid must be null on local-only create");
+        Assert.That(row!.MicrotingUid, Is.Not.Null, "synthetic MicrotingUid should be assigned");
+        Assert.That(row.MicrotingUid!.Value, Is.GreaterThanOrEqualTo(2_000_000_000),
+            "synthetic MicrotingUids live in the reserved local range");
         Assert.That(row.Id, Is.GreaterThan(0));
     }
 


### PR DESCRIPTION
## Summary

Closes a data-corruption bug where every \`CaseCreateLocalOnly\` call collapsed onto a single shared \`Cases\` row, with that row's \`CheckListId\` ricocheting across multiple templates as each new compliance overwrote it. On a customer running the flutter-eform mobile client against PR #4636's \`CaseCreateLocalOnly\` overload, **12 distinct Compliances ended up pointing to one \`Cases\` row whose \`CheckListId\` had been overwritten 18 times across 4 different templates**.

Root cause: \`SqlController.CaseCreate\`'s dedup probe matched on \`(MicrotingUid, MicrotingCheckUid)\` — both NULL for every local-only call — so every new local-only Cases row found and overwrote the same prior row.

## Fixes

- **Null-guard in \`SqlController.CaseCreate\` dedup** — skip the probe when \`microtingUid == null\`. Cloud-deploy recovery (the original purpose of dedup) is preserved unchanged.
- **\`Settings.skipCloudDeploy\`** — when \`"true"\`, \`Core.SendXml\` short-circuits without contacting the Microting cloud and returns a \`Response\` wrapping a synthetic MicrotingUid in a reserved local range (\`>= 2_000_000_000\`). Defaults to \`"false"\` — existing installations keep cloud-deploy behavior unchanged.
- **\`CaseCreateLocalOnly\`** — allocates a synthetic MicrotingUid instead of passing \`null\`. Cases rows now carry real-looking identifiers; downstream lookups stop having to special-case null.
- **\`Settings.syntheticMicrotingUidCounter\` + \`SqlController.NextSyntheticMicrotingUidAsync\`** — atomic UID allocation via MySQL's \`LAST_INSERT_ID(expr)\` idiom. Row-locked UPDATE + session-scoped LAST_INSERT_ID. Thread-safe within a process AND process-safe across separate hosts hitting the same DB. Seed-and-retry when the counter row is missing (post-upgrade). Explicit range guard before the \`(int)\` cast.
- **\`SettingReadOrDefaultAsync\` helper** — for callers that legitimately treat a missing row as "default behavior".

## Backward compatibility

- \`Settings.skipCloudDeploy\` defaults to \`"false"\` → existing cloud-deploy installations see no behavior change.
- \`SettingCreateDefaults\` seeds the new rows on init; pre-existing installations get them on next SDK startup or via \`NextSyntheticMicrotingUidAsync\`'s seed-and-retry path.
- \`CaseCreateLocalOnly\` callers continue to receive a \`Cases.Id\` return value. The internal \`microtingUid\` parameter passed to \`SqlController.CaseCreate\` flipped from \`null\` to a synthetic int. Existing integration test updated.

## Test plan

- [x] \`dotnet build\` clean.
- [x] Live-tested on a flutter-eform dev backend (customer 420) with \`Settings.skipCloudDeploy = "true"\` seeded. Compliance 6705 (today's event) was previously bound to corrupted Case 11351 (MicrotingUid=NULL, CheckListId bouncing across 4 templates, 44 stray FieldValues from 4 different CheckLists). After this fix:
  - Soft-removed Case 11351 + reset \`MicrotingSdkCaseId=0\` on 11 affected Compliances.
  - On next \`ListEvents\` from the mobile client, \`EventDeployService\` calls \`CaseCreateLocalOnly\` for each Compliance.
  - Each gets a fresh \`Cases\` row with a synthetic MicrotingUid in the \`2_000_000_001+\` range.
  - User confirmed eforms render correctly on device.
- [x] Pre-commit dual gate (code-reviewer + code-simplifier in parallel) ran twice. First pass surfaced 5 items (test-needs-update, malformed XML doc, bare-catch, missing-row guard, overflow guard); all resolved. Re-run came back clean.
- [x] Updated \`CoreTestCaseCreate.Core_Case_CaseCreateLocalOnly_InsertsRowWithSyntheticMicrotingUid\` (renamed from \`…WithNullMicrotingUid\`) asserts \`MicrotingUid >= 2_000_000_000\`.

## Concurrency notes

The \`NextSyntheticMicrotingUidAsync\` design uses MySQL's \`LAST_INSERT_ID(expr)\` idiom:

\`\`\`sql
UPDATE Settings
   SET Value = CAST(LAST_INSERT_ID(CAST(Value AS UNSIGNED) + 1) AS CHAR)
 WHERE Name = 'syntheticMicrotingUidCounter';
SELECT LAST_INSERT_ID();
\`\`\`

Both statements run on the same captured \`DbConnection\`. The UPDATE acquires an InnoDB row lock; each caller's \`LAST_INSERT_ID\` is session-scoped, so the SELECT returns the value THIS caller's UPDATE wrote. Safe across threads within one process AND across separate processes hitting the same DB.

## Follow-ups (not in this PR)

- The plugin's \`EventDeployService\` still uses \`CaseCreateLocalOnly\`. With this PR landed and NuGet propagated, the plugin can migrate to \`CaseCreate\` (relying on \`Settings.skipCloudDeploy=true\` to do the right thing transparently). That's a separate plugin PR.
- The data corruption from prior calls (Cases rows with NULL MicrotingUid holding mixed-template FieldValues) is not unwound by this fix. Cleanup is per-install: soft-remove the bad rows and reset \`MicrotingSdkCaseId=0\` on dependent Compliances so EventDeployService redeploys them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)