### PR TITLE
fix: guard SqlController Migrate() with IHistoryRepository.Exists()

### DIFF
--- a/eFormCore/Infrastructure/SqlController.cs
+++ b/eFormCore/Infrastructure/SqlController.cs
@@ -30,6 +30,8 @@ using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microting.eForm.Dto;
 using Microting.eForm.Infrastructure.Data.Entities;
 using Microting.eForm.Infrastructure.Helpers;
@@ -75,7 +77,8 @@ public class SqlController : LogWriter
         try
         {
             using var db = GetContext();
-            if (db.Database.GetPendingMigrations().Any())
+            var historyRepo = db.GetService<IHistoryRepository>();
+            if (!historyRepo.Exists() || db.Database.GetPendingMigrations().Any())
             {
                 WriteDebugConsoleLogEntry(new LogEntry(2, methodName,
                     $"{DateTime.Now} : db.Database.Migrate() called"));


### PR DESCRIPTION
## Summary

Add `IHistoryRepository.Exists()` guard around `Database.Migrate()` in `SqlController` so DDL is only issued when actually needed.

## Why

The existing `GetPendingMigrations().Any()` guard throws (and re-throws) if `__EFMigrationsHistory` doesn't exist yet, crashing startup on a fresh SDK DB. With the `IHistoryRepository.Exists()` outer guard:

- **Fresh install**: `Exists()` = false → falls through to `Migrate()` → creates schema ✅  
- **Schema current (production)**: `Exists()` = true, `GetPendingMigrations()` = empty → skips entirely, **no DDL, no GET_LOCK** ✅  
- **Pending migrations**: `Exists()` = true, pending found → `Migrate()` applies them ✅

On a Galera cluster with ~250 tenants, this eliminates SDK DDL from every pod restart.

## Test Plan
- [ ] Fresh SDK DB: migrations run and schema is created
- [ ] Existing SDK DB (schema current): no DDL on restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)