### PR TITLE
fix(core): prevent orphan sites from failed SiteCreate; null-safe SiteDelete

### DIFF
--- a/eFormCore/Core.cs
+++ b/eFormCore/Core.cs
@@ -2971,6 +2971,9 @@ public class Core : CoreBase
             // name. Remove them directly (Advanced_SiteItemDelete bypasses SiteRead, which throws on
             // worker-less sites, and soft-deletes the Site + entity items + remote). Never let cleanup
             // mask the original failure.
+            // Residual: Advanced_SiteItemDelete only soft-deletes the local Site when the remote deregister
+            // succeeds; if the remote call returns false the local row survives. The downstream plugin
+            // cleanup (name-based) covers that case.
             if (createdSiteMicrotingUid.HasValue)
             {
                 try

--- a/eFormCore/Core.cs
+++ b/eFormCore/Core.cs
@@ -2875,6 +2875,8 @@ public class Core : CoreBase
     {
         string methodName = "Core.SiteCreate";
         await using var db = DbContextHelper.GetDbContext();
+        int? createdSiteMicrotingUid = null;
+        int? createdWorkerMicrotingUid = null;
         try
         {
             if (!Running()) throw new Exception("Core is not running");
@@ -2899,6 +2901,7 @@ public class Core : CoreBase
             await searchableList.Update(db);
 
             Tuple<SiteDto, UnitDto> siteResult = await _communicator.SiteCreate(name, languageCode);
+            createdSiteMicrotingUid = siteResult.Item1.SiteId;
 
             //string token = await _sqlController.SettingRead(Settings.token).ConfigureAwait(false);
             int customerNo = int.Parse(_sqlController.SettingRead(Settings.customerNo).ConfigureAwait(false)
@@ -2955,6 +2958,7 @@ public class Core : CoreBase
 
             WorkerDto workerDto = await Advanced_WorkerCreate(userFirstName, userLastName, userEmail)
                 .ConfigureAwait(false);
+            createdWorkerMicrotingUid = workerDto.WorkerUId;
             await Advanced_SiteWorkerCreate(siteDto, workerDto).ConfigureAwait(false);
 
             return await SiteRead(siteId).ConfigureAwait(false);
@@ -2962,6 +2966,33 @@ public class Core : CoreBase
         catch (Exception ex)
         {
             Log.LogFail(methodName, "failed", ex);
+            // Compensating cleanup: a failure here can leave the remotely-registered, locally-committed
+            // Site (and possibly Worker) with no SiteWorker link — an orphan that blocks recreating the
+            // name. Remove them directly (Advanced_SiteItemDelete bypasses SiteRead, which throws on
+            // worker-less sites, and soft-deletes the Site + entity items + remote). Never let cleanup
+            // mask the original failure.
+            if (createdSiteMicrotingUid.HasValue)
+            {
+                try
+                {
+                    await Advanced_SiteItemDelete(createdSiteMicrotingUid.Value).ConfigureAwait(false);
+                }
+                catch (Exception cleanupEx)
+                {
+                    Log.LogFail(methodName, "compensating Advanced_SiteItemDelete failed", cleanupEx);
+                }
+            }
+            if (createdWorkerMicrotingUid.HasValue)
+            {
+                try
+                {
+                    await Advanced_WorkerDelete(createdWorkerMicrotingUid.Value).ConfigureAwait(false);
+                }
+                catch (Exception cleanupEx)
+                {
+                    Log.LogFail(methodName, "compensating Advanced_WorkerDelete failed", cleanupEx);
+                }
+            }
             throw new Exception("failed", ex);
         }
     }
@@ -3071,10 +3102,16 @@ public class Core : CoreBase
 
             if (siteDto == null) return false;
             await Advanced_SiteItemDelete(microtingUid).ConfigureAwait(false);
-            SiteWorkerDto siteWorkerDto = await Advanced_SiteWorkerRead(null, microtingUid, siteDto.WorkerUid)
-                .ConfigureAwait(false);
-            await Advanced_SiteWorkerDelete(siteWorkerDto.MicrotingUId).ConfigureAwait(false);
-            await Advanced_WorkerDelete((int)siteDto.WorkerUid).ConfigureAwait(false);
+            if (siteDto.WorkerUid != null)
+            {
+                SiteWorkerDto siteWorkerDto = await Advanced_SiteWorkerRead(null, microtingUid, siteDto.WorkerUid)
+                    .ConfigureAwait(false);
+                if (siteWorkerDto != null)
+                {
+                    await Advanced_SiteWorkerDelete(siteWorkerDto.MicrotingUId).ConfigureAwait(false);
+                }
+                await Advanced_WorkerDelete((int)siteDto.WorkerUid).ConfigureAwait(false);
+            }
             return true;
         }
         catch (Exception ex)

--- a/eFormSDK.Integration.Base.CoreTests/CoreTestSite.cs
+++ b/eFormSDK.Integration.Base.CoreTests/CoreTestSite.cs
@@ -694,6 +694,67 @@ public class CoreTestSite : DbTestFixture
         //#endregion
     }
 
+    [Test] //Using Communicatorn needs httpMock
+    public async Task Core_Advanced_SiteItemDelete_OnSiteWithoutSiteWorker_SoftDeletesSite()
+    {
+        // Arrange: a pure orphan site — no Worker, no SiteWorker, no Unit. This mirrors what a
+        // failed SiteCreate leaves behind, and what the compensating cleanup must be able to remove
+        // without hitting SiteRead (which throws .First() on a worker-less site).
+        string siteName = Guid.NewGuid().ToString();
+        int siteMicrotingUid = 1; // This needs to be 1 for our tests to pass through the FakeHttp
+        // TODO: Improve the test for supporting random id.
+
+        Site site = await testHelpers.CreateSite(siteName, siteMicrotingUid);
+
+        await using MicrotingDbContext db = _dbContextHelper.GetDbContext();
+        EntityGroup entityGroup = new EntityGroup
+        {
+            Editable = true,
+            Locked = false,
+            Name = "Device users",
+            Type = Constants.FieldTypes.EntitySearch
+        };
+
+        await entityGroup.Create(db);
+
+        EntityItem entityItem = new EntityItem
+        {
+            Name = siteName,
+            EntityGroupId = entityGroup.Id
+        };
+        await entityItem.Create(db);
+        site.SearchableEntityItemId = entityItem.Id;
+        await site.Update(db);
+
+        entityGroup = new EntityGroup
+        {
+            Editable = true,
+            Locked = false,
+            Name = "Device users",
+            Type = Constants.FieldTypes.EntitySelect
+        };
+
+        await entityGroup.Create(db);
+
+        entityItem = new EntityItem
+        {
+            Name = siteName,
+            EntityGroupId = entityGroup.Id
+        };
+        await entityItem.Create(db);
+        site.SelectableEntityItemId = entityItem.Id;
+        await site.Update(db);
+
+        // Act
+        var match = await sut.Advanced_SiteItemDelete((int)site.MicrotingUid);
+
+        // Assert
+        Assert.That(match, Is.True);
+        Site deletedSite = await db.Sites.FirstOrDefaultAsync(x => x.Id == site.Id);
+        Assert.That(deletedSite, Is.Not.Null);
+        Assert.That(deletedSite.WorkflowState, Is.EqualTo(Constants.WorkflowStates.Removed));
+    }
+
     #endregion
 
     #region eventhandlers


### PR DESCRIPTION
Closes #4695.

## Problem
`Core.SiteCreate` registers a site remotely and commits the local `Sites` row, then creates the EntityItems / Unit / Worker / SiteWorker in separate non-transactional steps with no rollback. If any step throws, the `Sites` row is left **active with no Worker/SiteWorker** — an orphan that permanently blocks recreating a worker by that name (downstream `Sites.Name` duplicate check). Separately, `Core.SiteDelete` NRE'd on worker-less sites (`siteWorkerDto`/`WorkerUid` dereferenced unguarded), so it couldn't be used to recover orphans.

## Fix
- **`SiteCreate` compensating cleanup**: track the remotely-created site uid (and worker uid, if reached) and, on exception, remove them via `Advanced_SiteItemDelete` (site + entity items + remote deregister + local soft-delete) and `Advanced_WorkerDelete` (worker). Each cleanup is wrapped so it never masks the original exception, which is always re-thrown. Cleanup routes through `Advanced_SiteItemDelete` (not `SiteDelete`) deliberately: `SiteDelete`→`SiteReadSimple` calls `.First()` on the SiteWorkers set and throws on worker-less sites, so it cannot clean an orphan; `Advanced_SiteItemDelete` removes the site directly.
- **`SiteDelete` null-safety**: guard `siteDto.WorkerUid != null` and `siteWorkerDto != null` so deleting a site with no SiteWorker no longer NREs and still soft-deletes the site + entity items. Happy path (fully-formed worker) unchanged.
- **Test**: `Core_Advanced_SiteItemDelete_OnSiteWithoutSiteWorker_SoftDeletesSite` — arranges a worker-less orphan site and asserts it is soft-deleted without throwing.

## Notes / limitations
- **Known residual**: `Advanced_SiteItemDelete` only soft-deletes the local row when the remote deregister succeeds; a remote failure leaves the local orphan. This mirrors the existing primitive contract and is covered operationally by the downstream plugin mitigation (microting/eform-backendconfiguration-plugin#1004), which cleans the local row by name. A belt-and-suspenders compensation-local forced soft-delete could be a follow-up.
- The deployable mitigation already shipped plugin-side (#1004); this is the SDK root-cause fix and requires a NuGet release to take effect in hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)