### PR TITLE
fix(core): look up languages by LanguageCode, never by Name

### DIFF
--- a/eFormCore/Core.cs
+++ b/eFormCore/Core.cs
@@ -2916,16 +2916,9 @@ public class Core : CoreBase
                     .ConfigureAwait(false);
             if (site == null)
             {
-                Language language = await db.Languages.FirstOrDefaultAsync(x => x.LanguageCode == languageCode);
-                if (language == null)
-                {
-                    if (languageCode == "da")
-                    {
-                        language = await db.Languages.FirstAsync(x => x.Name == "Dansk");
-                        language.LanguageCode = "da";
-                        await language.Update(db);
-                    }
-                }
+                Language language = await db.Languages.FirstOrDefaultAsync(x => x.LanguageCode == languageCode)
+                                    ?? throw new InvalidOperationException(
+                                        $"No language found with LanguageCode '{languageCode}'");
 
                 site = new Site
                 {
@@ -4184,12 +4177,13 @@ public class Core : CoreBase
         };
 
         await using var db = DbContextHelper.GetDbContext();
-        var language = await db.Languages.FirstOrDefaultAsync(x => x.Name == "Dansk").ConfigureAwait(false);
+        var language = await db.Languages.FirstOrDefaultAsync(x => x.LanguageCode == "da").ConfigureAwait(false);
         if (language == null)
         {
             language = new Language
             {
-                Name = "Dansk"
+                Name = "Dansk",
+                LanguageCode = "da"
             };
             await language.Create(db);
         }
@@ -4326,7 +4320,7 @@ public class Core : CoreBase
                     }
 
                     answer.QuestionSet = null;
-                    answer.LanguageId = db.Languages.First(x => x.Name == "Dansk").Id;
+                    answer.LanguageId = db.Languages.First(x => x.LanguageCode == "da").Id;
                     await answer.Create(db).ConfigureAwait(false);
 
                     foreach (JToken avItem in subItem["AnswerValues"])

--- a/eFormCore/Helpers/TestHelpers.cs
+++ b/eFormCore/Helpers/TestHelpers.cs
@@ -53,7 +53,7 @@ public class TestHelpers
         // // {
         // //     Console.WriteLine(language1.Name);
         // // }
-        language = await dbContext.Languages.FirstOrDefaultAsync(x => x.Name == "Dansk");
+        language = await dbContext.Languages.FirstOrDefaultAsync(x => x.LanguageCode == "da");
     }
 
     private MicrotingDbContext GetContext(string connectionStr)

--- a/eFormCore/Infrastructure/Data/Entities/CheckList.cs
+++ b/eFormCore/Infrastructure/Data/Entities/CheckList.cs
@@ -142,7 +142,7 @@ public class CheckList : PnBase
     public static async Task MoveTranslations(MicrotingDbContext dbContext)
     {
         List<CheckList> checkLists = await dbContext.CheckLists.ToListAsync();
-        Language language = await dbContext.Languages.FirstAsync(x => x.Name == "Dansk");
+        Language language = await dbContext.Languages.FirstAsync(x => x.LanguageCode == "da");
         foreach (CheckList checkList in checkLists)
         {
             if (!string.IsNullOrEmpty(checkList.Label))

--- a/eFormCore/Infrastructure/Data/Entities/Field.cs
+++ b/eFormCore/Infrastructure/Data/Entities/Field.cs
@@ -130,9 +130,9 @@ public class Field : PnBase
             FieldType pdfFieldType =
                 await dbContext.FieldTypes.FirstOrDefaultAsync(
                     x => x.Type == Constants.Constants.FieldTypes.ShowPdf);
-            Language language = await dbContext.Languages.FirstAsync(x => x.Name == "Dansk");
-            Language englishLanguage = await dbContext.Languages.FirstAsync(x => x.Name == "English");
-            Language DanskLanguage = await dbContext.Languages.FirstAsync(x => x.Name == "Dansk");
+            Language language = await dbContext.Languages.FirstAsync(x => x.LanguageCode == "da");
+            Language englishLanguage = await dbContext.Languages.FirstAsync(x => x.LanguageCode == "en-US");
+            Language DanskLanguage = await dbContext.Languages.FirstAsync(x => x.LanguageCode == "da");
             int i = 0;
             int totalFields = fields.Count;
             foreach (Field field in fields)

--- a/eFormCore/Infrastructure/Data/Entities/Site.cs
+++ b/eFormCore/Infrastructure/Data/Entities/Site.cs
@@ -67,7 +67,7 @@ public class Site : PnBase
     {
         List<Site> sites = await dbContext.Sites.ToListAsync();
         Language language = await dbContext.Languages
-            .FirstAsync(x => x.Name == "Dansk");
+            .FirstAsync(x => x.LanguageCode == "da");
         foreach (Site site in sites)
         {
             if (site.LanguageId == 0)

--- a/eFormSDK.Integration.Base.SqlControllerTests/SqlControllerTestField.cs
+++ b/eFormSDK.Integration.Base.SqlControllerTests/SqlControllerTestField.cs
@@ -62,7 +62,7 @@ public class SqlControllerTestField : DbTestFixture
         await sut.SettingUpdate(Settings.fileLocationPicture, @"\output\dataFolder\picture\");
         await sut.SettingUpdate(Settings.fileLocationPdf, @"\output\dataFolder\pdf\");
         await sut.SettingUpdate(Settings.fileLocationJasper, @"\output\dataFolder\reports\");
-        language = DbContext.Languages.Single(x => x.Name == "Dansk");
+        language = DbContext.Languages.Single(x => x.LanguageCode == "da");
     }
 
     [Test]

--- a/eFormSDK.Integration.Base.SqlControllerTests/SqlControllerTestFieldValue.cs
+++ b/eFormSDK.Integration.Base.SqlControllerTests/SqlControllerTestFieldValue.cs
@@ -66,7 +66,7 @@ public class SqlControllerTestFieldValue : DbTestFixture
         await sut.SettingUpdate(Settings.fileLocationPicture, @"\output\dataFolder\picture\");
         await sut.SettingUpdate(Settings.fileLocationPdf, @"\output\dataFolder\pdf\");
         await sut.SettingUpdate(Settings.fileLocationJasper, @"\output\dataFolder\reports\");
-        language = DbContext.Languages.Single(x => x.Name == "Dansk");
+        language = DbContext.Languages.Single(x => x.LanguageCode == "da");
     }
 
     [Test]

--- a/eFormSDK.Integration.Case.CoreTests/CoreTestCase.cs
+++ b/eFormSDK.Integration.Case.CoreTests/CoreTestCase.cs
@@ -55,7 +55,7 @@ public class CoreTestCase : DbTestFixture
         await sut.SetSdkSetting(Settings.fileLocationJasper, Path.Combine(path, "output", "dataFolder", "reports"));
         testHelpers = new TestHelpers(ConnectionString);
         await testHelpers.GenerateDefaultLanguages();
-        language = DbContext.Languages.AsNoTracking().Single(x => x.Name == "Dansk");
+        language = DbContext.Languages.AsNoTracking().Single(x => x.LanguageCode == "da");
         //await sut.StartLog(new CoreBase());
     }
 

--- a/eFormSDK.Integration.Case.SqlControllerTests/SqlControllerTestCase.cs
+++ b/eFormSDK.Integration.Case.SqlControllerTests/SqlControllerTestCase.cs
@@ -67,7 +67,7 @@ public class SqlControllerTestCase : DbTestFixture
         await sut.SettingUpdate(Settings.fileLocationPicture, @"\output\dataFolder\picture\");
         await sut.SettingUpdate(Settings.fileLocationPdf, @"\output\dataFolder\pdf\");
         await sut.SettingUpdate(Settings.fileLocationJasper, @"\output\dataFolder\reports\");
-        language = DbContext.Languages.Single(x => x.Name == "Dansk");
+        language = DbContext.Languages.Single(x => x.LanguageCode == "da");
     }
 
     [Test]

--- a/eFormSDK.Integration.Case.SqlControllerTests/SqlControllerTestCaseReadAllShort.cs
+++ b/eFormSDK.Integration.Case.SqlControllerTests/SqlControllerTestCaseReadAllShort.cs
@@ -74,7 +74,7 @@ public class SqlControllerTestCaseReadAllShort : DbTestFixture
         await sut.SettingUpdate(Settings.fileLocationPicture, @"\output\dataFolder\picture\");
         await sut.SettingUpdate(Settings.fileLocationPdf, @"\output\dataFolder\pdf\");
         await sut.SettingUpdate(Settings.fileLocationJasper, @"\output\dataFolder\reports\");
-        language = DbContext.Languages.Single(x => x.Name == "Dansk");
+        language = DbContext.Languages.Single(x => x.LanguageCode == "da");
     }
 
     #region template

--- a/eFormSDK.Integration.CheckLists.CoreTests/CoreTestAdvanced.cs
+++ b/eFormSDK.Integration.CheckLists.CoreTests/CoreTestAdvanced.cs
@@ -83,7 +83,7 @@ public class CoreTestAdvanced : DbTestFixture
         await sut.SetSdkSetting(Settings.fileLocationJasper, Path.Combine(path, "output", "dataFolder", "reports"));
         testHelpers = new TestHelpers(ConnectionString);
         await testHelpers.GenerateDefaultLanguages();
-        language = DbContext.Languages.Single(x => x.Name == "Dansk");
+        language = DbContext.Languages.Single(x => x.LanguageCode == "da");
         //sut.StartLog(new CoreBase());
     }
 

--- a/eFormSDK.Integration.CheckLists.CoreTests/CoreTesteForm.cs
+++ b/eFormSDK.Integration.CheckLists.CoreTests/CoreTesteForm.cs
@@ -83,7 +83,7 @@ public class CoreTesteForm : DbTestFixture
         testHelpers = new TestHelpers(ConnectionString);
         await testHelpers.GenerateDefaultLanguages();
         //sut.StartLog(new CoreBase());
-        language = DbContext.Languages.Single(x => x.Name == "Dansk");
+        language = DbContext.Languages.Single(x => x.LanguageCode == "da");
     }
 
     #region template

--- a/eFormSDK.Integration.CheckLists.SqlControllerTests/SqlControllerTestReplyElementy.cs
+++ b/eFormSDK.Integration.CheckLists.SqlControllerTests/SqlControllerTestReplyElementy.cs
@@ -68,7 +68,7 @@ public class SqlControllerTestReplyElementy : DbTestFixture
         await sut.SettingUpdate(Settings.fileLocationPicture, @"\output\dataFolder\picture\");
         await sut.SettingUpdate(Settings.fileLocationPdf, @"\output\dataFolder\pdf\");
         await sut.SettingUpdate(Settings.fileLocationJasper, @"\output\dataFolder\reports\");
-        language = DbContext.Languages.Single(x => x.Name == "Dansk");
+        language = DbContext.Languages.Single(x => x.LanguageCode == "da");
     }
 
     [Test]


### PR DESCRIPTION
## Why

`Language.Name` holds the language's name in its own native language (`Türkçe`, `Čeština`, `Ελληνικά`) so a native speaker can find their language in a picker. It is display text and was never a valid lookup key. `LanguageCode` is the identity column — `AddDefaultLanguages` already dedups on it, and ~40 call sites already use it.

Eight lookups were still keyed on `Name`. The one in `Core.SaveAnswer` silently killed InSight answer ingestion for any tenant seeded before the native-name convention landed. Those tenants have `Name='Danish'` / `LanguageCode='da'`, so:

```csharp
answer.LanguageId = db.Languages.First(x => x.Name == "Dansk").Id;
```

threw `InvalidOperationException: Sequence contains no elements` for **every** answer, and the enclosing `catch` swallowed it into a `Console.WriteLine($"fail: ...")` — no SDK log entry, no `Notifications` row.

### Confirmed impact on one tenant

Ingestion hard-stopped on 2025-03-21. Verified read-only against the production API with the tenant's own token:

| | |
|---|---|
| Missing answers | **96** |
| Missing answer values | **1020** |
| Date range | 2025-03-21 → 2026-07-06 |
| Local max `MicrotingUid` | 12830155 (server backlog starts at 12830157) |

The gap is a clean suffix — no orphans, no broken FKs, `AnswerVersions` 1:1 with `Answers` — so ingestion did not degrade, it stopped dead.

### Why it can never self-heal

`AddDefaultLanguages` dedups on `LanguageCode` (`Language.cs:75`), so a tenant that already has a `da` row never receives the seed's `new("Dansk", "da")`. `LanguageCode` was not a new column either — `20201231062732_ChangingDescriptToLanguageCode` **renames** `Description` to `LanguageCode`, so legacy rows inherited whatever free text or NULL sat there.

### History

| Commit | Date | Effect |
|---|---|---|
| `73b988f8` | 2023-07-22 | changed `x.Name == "Danish"` to `x.Name == "Dansk"`; first released in **v7.0.57** |
| `c06c9e9c` | 2024-11-28 | removed the startup block that renamed `Danish`→`Dansk`, making the fault permanent |

Between those two commits the fault was masked by that self-repair. After `c06c9e9c` it is permanent for every affected tenant.

## What changed

All language lookups now key on `LanguageCode`. Zero `Name`-keyed language lookups remain repo-wide (excluding `Migrations/`).

- `Core.SaveAnswer`, `Core.GetAllQuestionSets`, `Core` site creation, `CheckList.MoveTranslations`, `Field.MoveTranslations`, `Site.AddLanguage`, `TestHelpers`, and 8 integration tests.
- The fallback `Language` created in `GetAllQuestionSets` now sets `LanguageCode`, which it previously left NULL — such a row is invisible to every lookup in the SDK, and post-change `SaveAnswer` would have thrown on the row it had just created.
- Site creation drops the legacy `Name`-based self-repair. It could only ever fire for a row *already* named `Dansk`, so it never helped the tenants it was meant to; it now throws naming the missing code instead of dereferencing null — the same outcome with a diagnosable message.

Codes verified against the seed list in `Language.cs:44-70` (`Dansk`→`da`, `English`→`en-US`).

`Field.MoveTranslations`, `CheckList.MoveTranslations` and `Site.AddLanguage` have no live callers (commented out at `SqlController.cs:107-109`), so those edits are for consistency only. The runtime blast radius is `Core.cs` (3 sites) plus `TestHelpers.cs`.

## Verification

`dotnet build eFormSDK.sln` — 0 errors, 8 pre-existing NuGet warnings. Integration tests need a MySQL instance and were not run locally; CI covers them.

Test fixtures seed `Languages` from `eformsdk-tests.sql` with exactly one row per code, so `Single(x => x.LanguageCode == "da")` resolves to the same row the old `Single(x => x.Name == "Dansk")` did.

## Follow-ups (not in this PR)

1. `Core.cs` `SaveAnswer` still swallows every per-answer exception into `Console.WriteLine`. That is why this outage was invisible for 16 months. Four other unguarded throwing calls sit inside the same `try` (`Questions.FirstAsync`, `Options.FirstAsync`, `OptionTranslations.FirstAsync`, the `GetSite` deserialize path).
2. `SaveAnswers` returns the server's `NumAnswers` rather than the count actually persisted, so `while (numAnswers > 9)` cannot terminate when nothing saves — an infinite hot loop against the API. With Rebus at 1 worker this wedges all notification processing for the tenant.
3. Consider making `Language.LanguageCode` `[Required]` with a unique index. ~40 call sites treat it as the identity key; the schema currently says nullable `longtext`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0118LWz5kZpYz6fci2C42dfJ
